### PR TITLE
Changed date formatter to copy text Older for entries older than 24h

### DIFF
--- a/freeza/freeza/NSDate+AgeFormatter.swift
+++ b/freeza/freeza/NSDate+AgeFormatter.swift
@@ -39,14 +39,10 @@ extension Date {
             
             return "\(secondsAgo / (60 * 60)) hours ago"
 
-        } else if secondsAgo < 2 * 24 * 60 * 60 {
+        } else if secondsAgo < 2 * 24 * 60 * 60 || secondsAgo < 6 * 24 * 60 * 60 {
             
-            return "A day ago"
+            return "older"
 
-        } else if secondsAgo < 6 * 24 * 60 * 60 {
-            
-            return "\(secondsAgo / (24 * 60 * 60)) days ago"
-            
         } else {
             
             return "A long time ago"


### PR DESCRIPTION
Modified copy for NSDateFormatter extension to read 'older' for entries older than 24 hours. 